### PR TITLE
Add standalone v1 CLI for data loading and training

### DIFF
--- a/Eviformer/cli_v1.py
+++ b/Eviformer/cli_v1.py
@@ -1,0 +1,188 @@
+"""Command line interface for training and evaluating Eviformer models (refactored v1)."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+
+from data_pipeline_v1 import DatasetSummaryV1, build_dataloaders_v1, scan_data_root_v1
+from evaluation_v1 import evaluate_dataloaders_v1
+from helpers import get_device, set_seed
+from model_factory_v1 import LOSS_REGISTRY_V1, MODEL_CHOICES_V1, build_model_v1, resolve_loss_v1
+from training_loop_v1 import train_model_v1
+
+LOSS_CHOICES_V1 = tuple(sorted(LOSS_REGISTRY_V1.keys()))
+
+
+def parse_args_v1(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train and evaluate Eviformer models (v1)")
+    parser.add_argument(
+        "mode",
+        choices=["train", "test", "inspect", "scan"],
+        help="Execution mode",
+    )
+    parser.add_argument("--data-root", type=Path, default=os.environ.get("CWRU_DATA_ROOT"))
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--val-split", type=float, default=0.2)
+    parser.add_argument("--test-split", type=float, default=0.0)
+    parser.add_argument("--window-size", type=int, default=1024)
+    parser.add_argument("--step-size", type=int, default=None)
+    parser.add_argument("--normalization", choices=["0-1", "-1-1", "mean-std"], default="-1-1")
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--model", choices=sorted(MODEL_CHOICES_V1), default="mcswint")
+    parser.add_argument("--dropout", action="store_true", help="Enable dropout for compatible models")
+    parser.add_argument("--epochs", type=int, default=100)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--weight-decay", type=float, default=5e-3)
+    parser.add_argument("--scheduler-step", type=int, default=7)
+    parser.add_argument("--scheduler-gamma", type=float, default=0.5)
+    parser.add_argument("--uncertainty", action="store_true")
+    parser.add_argument("--loss", choices=LOSS_CHOICES_V1, default="cross_entropy")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--device", type=str, default=None)
+    parser.add_argument("--checkpoint", type=Path, default=Path("./results/model_v1.pt"))
+    parser.add_argument(
+        "--evaluate-splits",
+        nargs="*",
+        default=None,
+        help="Specific dataset splits to evaluate during testing",
+    )
+    return parser.parse_args(argv)
+
+
+def ensure_data_root_v1(data_root: Optional[Path]) -> Path:
+    if data_root is None:
+        raise ValueError("`--data-root` must be provided or set via CWRU_DATA_ROOT")
+    return Path(data_root)
+
+
+def train_mode_v1(
+    args: argparse.Namespace,
+    summary: DatasetSummaryV1,
+    dataloaders: Dict[str, DataLoader],
+) -> None:
+    device = get_device(args.device)
+    num_classes = len(summary.label_to_index)
+    model = build_model_v1(args.model, num_classes, summary.window_size, args.dropout)
+    criterion = resolve_loss_v1(args.loss, args.uncertainty)
+    optimizer = optim.Adam(model.parameters(), lr=args.learning_rate, weight_decay=args.weight_decay)
+    scheduler = optim.lr_scheduler.StepLR(
+        optimizer, step_size=args.scheduler_step, gamma=args.scheduler_gamma
+    )
+    model, history = train_model_v1(
+        model,
+        dataloaders,
+        num_classes=num_classes,
+        criterion=criterion,
+        optimizer=optimizer,
+        scheduler=scheduler,
+        num_epochs=args.epochs,
+        device=device,
+        uncertainty=args.uncertainty,
+    )
+    args.checkpoint.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "model": args.model,
+        "num_classes": num_classes,
+        "state_dict": model.state_dict(),
+        "optimizer_state": optimizer.state_dict(),
+        "summary": asdict(summary),
+        "history": [vars(metric) for metric in history.epochs],
+        "best_epoch": history.best_epoch,
+        "best_accuracy": history.best_accuracy,
+        "duration_seconds": history.duration_seconds,
+        "dropout": args.dropout,
+        "loss": args.loss,
+        "uncertainty": args.uncertainty,
+    }
+    torch.save(payload, args.checkpoint)
+    print(f"Saved checkpoint to {args.checkpoint}")
+
+
+def test_mode_v1(
+    args: argparse.Namespace,
+    summary: DatasetSummaryV1,
+    dataloaders: Dict[str, DataLoader],
+) -> None:
+    device = get_device(args.device)
+    checkpoint = torch.load(args.checkpoint, map_location=device)
+    num_classes = checkpoint.get("num_classes", len(summary.label_to_index))
+    model_name = checkpoint.get("model", args.model)
+    checkpoint_summary = checkpoint.get("summary")
+    sequence_length = summary.window_size
+    if isinstance(checkpoint_summary, dict):
+        sequence_length = checkpoint_summary.get("window_size", sequence_length)
+    dropout_flag = checkpoint.get("dropout", args.dropout)
+    model = build_model_v1(model_name, num_classes, sequence_length, dropout_flag)
+    model.load_state_dict(checkpoint["state_dict"])
+
+    use_uncertainty = checkpoint.get("uncertainty", args.uncertainty)
+    splits = args.evaluate_splits or list(dataloaders.keys())
+    selected_loaders = {split: dataloaders[split] for split in splits if split in dataloaders}
+    if not selected_loaders:
+        raise ValueError("No valid dataloader splits selected for evaluation")
+    criterion = None
+    if not use_uncertainty:
+        criterion = nn.CrossEntropyLoss()
+    metrics = evaluate_dataloaders_v1(
+        model,
+        selected_loaders,
+        criterion=criterion,
+        device=device,
+        num_classes=num_classes,
+        uncertainty=use_uncertainty,
+    )
+    print(json.dumps({split: vars(result) for split, result in metrics.items()}, indent=2))
+
+
+def inspect_mode_v1(summary: DatasetSummaryV1) -> None:
+    print(json.dumps(asdict(summary), indent=2, default=str))
+
+
+def run_cli_v1(argv: Optional[Iterable[str]] = None) -> None:
+    args = parse_args_v1(argv)
+    set_seed(args.seed)
+
+    if args.mode == "scan":
+        data_root = ensure_data_root_v1(args.data_root)
+        scan_data_root_v1(data_root)
+        return
+
+    data_root = ensure_data_root_v1(args.data_root)
+    dataloaders, summary = build_dataloaders_v1(
+        data_root=data_root,
+        batch_size=args.batch_size,
+        val_split=args.val_split,
+        test_split=args.test_split,
+        window_size=args.window_size,
+        step_size=args.step_size,
+        normalization=args.normalization,
+        num_workers=args.num_workers,
+        random_state=args.seed,
+    )
+
+    if args.mode == "inspect":
+        inspect_mode_v1(summary)
+        return
+
+    if args.mode == "train":
+        train_mode_v1(args, summary, dataloaders)
+        return
+
+    if args.mode == "test":
+        test_mode_v1(args, summary, dataloaders)
+        return
+
+    raise ValueError(f"Unsupported mode: {args.mode}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    run_cli_v1()

--- a/Eviformer/data_pipeline_v1.py
+++ b/Eviformer/data_pipeline_v1.py
@@ -1,0 +1,307 @@
+"""Standalone data preparation utilities for the CWRU bearing dataset (v1)."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+from torch.utils.data import DataLoader
+
+from sequence_aug import Compose, Ensure2d, Normalize, ToFloat32
+from sequence_dataset_v1 import BearingSequenceDatasetV1, SequenceSampleV1
+
+__all__ = [
+    "DatasetSummaryV1",
+    "build_dataloaders_v1",
+    "discover_npz_files_v1",
+    "load_npz_segments_v1",
+    "split_indices_v1",
+    "scan_data_root_v1",
+]
+
+
+FAULT_KEYWORDS: Mapping[str, Tuple[str, ...]] = {
+    "normal": ("normal",),
+    "ball": ("_b_",),
+    "inner_race": ("_ir_",),
+    "outer_race": ("_or@",),
+}
+RPM_PATTERN = re.compile(r"(?P<rpm>\d+)\s*rpm", re.IGNORECASE)
+LOCATION_PATTERN = re.compile(r"_(DE|FE|BA)(\d+)?", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class DatasetSummaryV1:
+    """Lightweight metadata describing a prepared dataset."""
+
+    source_root: Path
+    label_to_index: Dict[str, int]
+    split_sizes: Dict[str, int]
+    window_size: int
+    step_size: int
+    samples_per_label: Dict[str, int]
+
+
+class DatasetAssemblyError(RuntimeError):
+    """Raised when raw ``.npz`` files cannot be converted into training samples."""
+
+
+def discover_npz_files_v1(root: Path) -> List[Path]:
+    """Recursively discover ``.npz`` files under ``root``."""
+
+    if not root.exists():
+        raise FileNotFoundError(f"Data root {root} does not exist")
+    files = sorted(path for path in root.rglob("*.npz") if path.is_file())
+    if not files:
+        raise FileNotFoundError(f"No .npz files were found under {root}")
+    return files
+
+
+def infer_fault_label_v1(filename: str) -> str:
+    lower = filename.lower()
+    for label, tokens in FAULT_KEYWORDS.items():
+        if any(token in lower for token in tokens):
+            return label
+    raise DatasetAssemblyError(f"Unable to infer fault label from filename: {filename}")
+
+
+def infer_rpm_v1(path: Path) -> Optional[int]:
+    for part in reversed(path.parts):
+        match = RPM_PATTERN.search(part)
+        if match:
+            return int(match.group("rpm"))
+    return None
+
+
+def infer_sensor_location_v1(filename: str) -> Optional[str]:
+    match = LOCATION_PATTERN.search(filename)
+    if match:
+        return match.group(1).upper()
+    return None
+
+
+def load_npz_segments_v1(
+    path: Path,
+    window_size: int,
+    step_size: Optional[int] = None,
+) -> np.ndarray:
+    """Load a ``.npz`` file and segment signals into fixed-length windows."""
+
+    step = step_size or window_size
+    with np.load(path) as npz_file:
+        arrays: List[np.ndarray] = []
+        for key in sorted(npz_file.files):
+            values = np.asarray(npz_file[key])
+            if values.ndim == 0:
+                continue
+            if values.ndim == 1:
+                arrays.append(values[np.newaxis, :])
+            else:
+                leading_dim = values.shape[0]
+                arrays.append(values.reshape(leading_dim, -1))
+    if not arrays:
+        raise DatasetAssemblyError(f"No usable arrays were found in {path}")
+    signals = np.concatenate(arrays, axis=0)
+    segments: List[np.ndarray] = []
+    for row in np.atleast_2d(signals):
+        if row.size < window_size:
+            raise DatasetAssemblyError(
+                f"Signal length {row.size} in {path} is shorter than window size {window_size}"
+            )
+        for start in range(0, row.size - window_size + 1, step):
+            segments.append(row[start : start + window_size])
+    return np.stack(segments)
+
+
+def assemble_samples_v1(
+    files: Sequence[Path],
+    window_size: int,
+    step_size: Optional[int],
+) -> Tuple[List[SequenceSampleV1], Dict[str, int], Dict[str, int]]:
+    label_to_index: Dict[str, int] = {}
+    samples: List[SequenceSampleV1] = []
+    per_label: Dict[str, int] = {}
+    for file_path in files:
+        fault_label = infer_fault_label_v1(file_path.name)
+        label_index = label_to_index.setdefault(fault_label, len(label_to_index))
+        rpm = infer_rpm_v1(file_path)
+        location = infer_sensor_location_v1(file_path.name)
+        segments = load_npz_segments_v1(file_path, window_size, step_size)
+        per_label[fault_label] = per_label.get(fault_label, 0) + len(segments)
+        for segment_idx, segment in enumerate(segments):
+            metadata = {
+                "source": file_path,
+                "fault_label": fault_label,
+                "rpm": rpm,
+                "sensor_location": location,
+                "segment": segment_idx,
+            }
+            samples.append(
+                SequenceSampleV1(values=segment, label=label_index, metadata=metadata)
+            )
+    return samples, label_to_index, per_label
+
+
+def split_indices_v1(
+    labels: Sequence[int],
+    val_split: float,
+    test_split: float,
+    random_state: int,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    indices = np.arange(len(labels))
+    labels_array = np.asarray(labels)
+    if val_split + test_split == 0:
+        return indices, np.array([], dtype=int), np.array([], dtype=int)
+    if test_split > 0:
+        train_indices, temp_indices, train_labels, temp_labels = train_test_split(
+            indices,
+            labels_array,
+            test_size=val_split + test_split,
+            stratify=labels_array,
+            random_state=random_state,
+        )
+        relative_test = test_split / (val_split + test_split)
+        val_indices, test_indices = train_test_split(
+            temp_indices,
+            test_size=relative_test,
+            stratify=temp_labels,
+            random_state=random_state,
+        )
+    else:
+        train_indices, val_indices = train_test_split(
+            indices,
+            labels_array,
+            test_size=val_split,
+            stratify=labels_array,
+            random_state=random_state,
+        )
+        test_indices = np.array([], dtype=int)
+    return train_indices, val_indices, test_indices
+
+
+def build_dataloaders_v1(
+    data_root: Path,
+    batch_size: int = 64,
+    val_split: float = 0.2,
+    test_split: float = 0.0,
+    window_size: int = 1024,
+    step_size: Optional[int] = None,
+    normalization: str = "-1-1",
+    num_workers: int = 0,
+    random_state: int = 42,
+) -> Tuple[Dict[str, DataLoader], DatasetSummaryV1]:
+    files = discover_npz_files_v1(data_root)
+    samples, label_to_index, per_label = assemble_samples_v1(files, window_size, step_size)
+    transform = Compose([Ensure2d(), Normalize(normalization), ToFloat32()])
+    dataset = BearingSequenceDatasetV1(samples, transform=transform)
+    train_idx, val_idx, test_idx = split_indices_v1(
+        dataset.labels, val_split, test_split, random_state
+    )
+
+    dataloaders: Dict[str, DataLoader] = {}
+    train_dataset = dataset.subset(train_idx) if len(train_idx) else dataset
+    dataloaders["train"] = DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+    )
+    if len(val_idx):
+        val_dataset = dataset.subset(val_idx)
+    else:
+        val_dataset = dataset.subset(train_idx) if len(train_idx) else dataset
+    dataloaders["val"] = DataLoader(
+        val_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+    )
+    if len(test_idx):
+        test_dataset = dataset.subset(test_idx)
+        dataloaders["test"] = DataLoader(
+            test_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+        )
+
+    summary = DatasetSummaryV1(
+        source_root=data_root,
+        label_to_index=label_to_index,
+        split_sizes={key: len(loader.dataset) for key, loader in dataloaders.items()},
+        window_size=window_size,
+        step_size=step_size or window_size,
+        samples_per_label=per_label,
+    )
+    return dataloaders, summary
+
+
+def scan_data_root_v1(root: Path) -> None:
+    """Utility helper that mimics the user's sample directory listing output."""
+
+    files = discover_npz_files_v1(root)
+    print(f"Scanning directory: '{root}'...")
+    print()
+    print(f"Found {len(files)} files. Listing all paths:")
+    print("-" * 60)
+    for path in files:
+        print(path)
+    print("-" * 60)
+    print("Scan complete.")
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Inspect CWRU bearing data (v1)")
+    parser.add_argument(
+        "--data-root",
+        type=Path,
+        default=os.environ.get("CWRU_DATA_ROOT"),
+        help="Root directory containing the downloaded CWRU `.npz` files.",
+    )
+    parser.add_argument("--scan", action="store_true", help="Print every discovered file path")
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--val-split", type=float, default=0.2)
+    parser.add_argument("--test-split", type=float, default=0.0)
+    parser.add_argument("--window-size", type=int, default=1024)
+    parser.add_argument("--step-size", type=int, default=None)
+    parser.add_argument(
+        "--normalization",
+        choices=["0-1", "-1-1", "mean-std"],
+        default="-1-1",
+    )
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--random-state", type=int, default=42)
+    args = parser.parse_args(argv)
+
+    if args.data_root is None:
+        raise ValueError("`--data-root` must be provided or set via CWRU_DATA_ROOT")
+    data_root = Path(args.data_root)
+
+    if args.scan:
+        scan_data_root_v1(data_root)
+        return
+
+    dataloaders, summary = build_dataloaders_v1(
+        data_root=data_root,
+        batch_size=args.batch_size,
+        val_split=args.val_split,
+        test_split=args.test_split,
+        window_size=args.window_size,
+        step_size=args.step_size,
+        normalization=args.normalization,
+        num_workers=args.num_workers,
+        random_state=args.random_state,
+    )
+    print(json.dumps(asdict(summary), indent=2, default=str))
+    for split, loader in dataloaders.items():
+        print(f"{split}: {len(loader.dataset)} samples")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use only
+    main()

--- a/Eviformer/evaluation_v1.py
+++ b/Eviformer/evaluation_v1.py
@@ -1,0 +1,97 @@
+"""Evaluation helpers for the refactored Eviformer CLI (v1)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import torch
+from torch.utils.data import DataLoader
+
+from helpers import get_device
+from losses import relu_evidence
+
+__all__ = ["EvaluationMetricsV1", "evaluate_model_v1", "evaluate_dataloaders_v1"]
+
+
+@dataclass
+class EvaluationMetricsV1:
+    loss: Optional[float]
+    accuracy: float
+    mean_uncertainty: Optional[float]
+    total_samples: int
+
+
+def evaluate_model_v1(
+    model: torch.nn.Module,
+    dataloader: DataLoader,
+    criterion=None,
+    device: Optional[torch.device] = None,
+    num_classes: Optional[int] = None,
+    uncertainty: bool = False,
+) -> EvaluationMetricsV1:
+    if device is None:
+        device = get_device()
+    model = model.to(device)
+    model.eval()
+
+    running_loss = 0.0
+    running_corrects = 0
+    total_uncertainty = 0.0
+    sample_count = 0
+
+    with torch.no_grad():
+        for batch in dataloader:
+            inputs, labels, *_ = batch
+            inputs = inputs.to(device)
+            labels = labels.to(device)
+            outputs = model(inputs)
+            _, preds = torch.max(outputs, 1)
+
+            if criterion is not None:
+                loss = criterion(outputs, labels)
+                running_loss += loss.item() * inputs.size(0)
+
+            running_corrects += torch.sum(preds == labels).item()
+            sample_count += inputs.size(0)
+
+            if uncertainty:
+                inferred_classes = num_classes or outputs.shape[-1]
+                evidence = relu_evidence(outputs)
+                alpha = evidence + 1
+                batch_uncertainty = (
+                    inferred_classes / torch.sum(alpha, dim=1, keepdim=True)
+                )
+                total_uncertainty += batch_uncertainty.sum().item()
+
+    accuracy = running_corrects / sample_count if sample_count else 0.0
+    loss_value = running_loss / sample_count if sample_count and criterion else None
+    mean_uncertainty = (
+        total_uncertainty / sample_count if sample_count and uncertainty else None
+    )
+    return EvaluationMetricsV1(
+        loss=loss_value,
+        accuracy=accuracy,
+        mean_uncertainty=mean_uncertainty,
+        total_samples=sample_count,
+    )
+
+
+def evaluate_dataloaders_v1(
+    model: torch.nn.Module,
+    dataloaders: Dict[str, DataLoader],
+    criterion=None,
+    device: Optional[torch.device] = None,
+    num_classes: Optional[int] = None,
+    uncertainty: bool = False,
+) -> Dict[str, EvaluationMetricsV1]:
+    metrics: Dict[str, EvaluationMetricsV1] = {}
+    for name, loader in dataloaders.items():
+        metrics[name] = evaluate_model_v1(
+            model,
+            loader,
+            criterion=criterion,
+            device=device,
+            num_classes=num_classes,
+            uncertainty=uncertainty,
+        )
+    return metrics

--- a/Eviformer/model_factory_v1.py
+++ b/Eviformer/model_factory_v1.py
@@ -1,0 +1,55 @@
+"""Model and loss factory helpers for the refactored CLI (v1)."""
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+import torch.nn as nn
+
+from lenet import LeNet
+from losses import edl_digamma_loss, edl_log_loss, edl_mse_loss
+from MCSwinT import mcswint
+from VIT import vit_middle_patch16
+
+__all__ = [
+    "LOSS_REGISTRY_V1",
+    "MODEL_CHOICES_V1",
+    "build_model_v1",
+    "resolve_loss_v1",
+]
+
+
+LOSS_REGISTRY_V1: Dict[str, Callable[[], Callable]] = {
+    "cross_entropy": nn.CrossEntropyLoss,
+    "mse": lambda: edl_mse_loss,
+    "log": lambda: edl_log_loss,
+    "digamma": lambda: edl_digamma_loss,
+}
+
+MODEL_CHOICES_V1 = ("mcswint", "vit", "lenet")
+
+
+def build_model_v1(name: str, num_classes: int, sequence_length: int, dropout: bool) -> nn.Module:
+    name = name.lower()
+    if name == "mcswint":
+        return mcswint(in_channel=1, out_channel=num_classes)
+    if name == "vit":
+        return vit_middle_patch16(
+            data_size=sequence_length,
+            in_c=1,
+            num_cls=num_classes,
+            h_args=[256, 128, 64, 32],
+        )
+    if name == "lenet":
+        return LeNet(dropout=dropout, num_classes=num_classes)
+    raise ValueError(f"Unknown model architecture: {name}")
+
+
+def resolve_loss_v1(loss_name: str, uncertainty: bool):
+    key = loss_name.lower()
+    if key not in LOSS_REGISTRY_V1:
+        raise ValueError(f"Unsupported loss function: {loss_name}")
+    if uncertainty and key == "cross_entropy":
+        raise ValueError("Cross entropy cannot be used with uncertainty training")
+    if not uncertainty and key != "cross_entropy":
+        raise ValueError("Uncertainty-aware losses require --uncertainty to be enabled")
+    return LOSS_REGISTRY_V1[key]()

--- a/Eviformer/sequence_dataset_v1.py
+++ b/Eviformer/sequence_dataset_v1.py
@@ -1,0 +1,68 @@
+"""Refactored dataset abstractions for sequential bearing data (v1)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+from sequence_aug import Compose, Ensure2d, ToFloat32
+
+__all__ = ["SequenceSampleV1", "BearingSequenceDatasetV1"]
+
+
+@dataclass(frozen=True)
+class SequenceSampleV1:
+    """Container describing a single labelled time-series segment."""
+
+    values: np.ndarray
+    label: int
+    metadata: Dict[str, object]
+
+
+class BearingSequenceDatasetV1(Dataset[Tuple[torch.Tensor, int]]):
+    """PyTorch dataset that wraps :class:`SequenceSampleV1` records."""
+
+    def __init__(
+        self,
+        samples: Sequence[SequenceSampleV1],
+        transform: Optional[Compose] = None,
+        return_metadata: bool = False,
+    ) -> None:
+        if not samples:
+            raise ValueError("`samples` must contain at least one item.")
+        self._samples = list(samples)
+        self._return_metadata = return_metadata
+        self._transform = transform or Compose([Ensure2d(), ToFloat32()])
+
+    def __len__(self) -> int:  # pragma: no cover - trivial container wrapper
+        return len(self._samples)
+
+    def __getitem__(self, index: int):
+        sample = self._samples[index]
+        values = np.asarray(sample.values)
+        values = self._transform(values)
+        tensor = torch.from_numpy(values)
+        if tensor.ndim == 1:
+            tensor = tensor.unsqueeze(0)
+        if self._return_metadata:
+            return tensor, sample.label, sample.metadata
+        return tensor, sample.label
+
+    @property
+    def labels(self) -> Sequence[int]:
+        return [sample.label for sample in self._samples]
+
+    @property
+    def metadata(self) -> Sequence[Dict[str, object]]:
+        return [sample.metadata for sample in self._samples]
+
+    def subset(self, indices: Iterable[int]) -> "BearingSequenceDatasetV1":
+        subset_samples = [self._samples[i] for i in indices]
+        return BearingSequenceDatasetV1(
+            subset_samples,
+            transform=self._transform,
+            return_metadata=self._return_metadata,
+        )

--- a/Eviformer/training_loop_v1.py
+++ b/Eviformer/training_loop_v1.py
@@ -1,0 +1,189 @@
+"""Training utilities used by the refactored Eviformer CLI (v1)."""
+from __future__ import annotations
+
+import copy
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import torch
+from torch.utils.data import DataLoader
+
+from helpers import get_device, one_hot_embedding
+from losses import relu_evidence
+
+__all__ = [
+    "TrainingConfigV1",
+    "EpochMetricsV1",
+    "TrainingHistoryV1",
+    "train_model_v1",
+]
+
+
+@dataclass
+class TrainingConfigV1:
+    num_epochs: int = 100
+    num_classes: int = 4
+    uncertainty: bool = False
+
+
+@dataclass
+class EpochMetricsV1:
+    epoch: int
+    phase: str
+    loss: float
+    accuracy: float
+    mean_evidence: Optional[float] = None
+    mean_evidence_success: Optional[float] = None
+    mean_evidence_fail: Optional[float] = None
+    mean_uncertainty: Optional[float] = None
+
+
+@dataclass
+class TrainingHistoryV1:
+    epochs: List[EpochMetricsV1]
+    best_epoch: int
+    best_accuracy: float
+    duration_seconds: float
+
+
+def train_model_v1(
+    model: torch.nn.Module,
+    dataloaders: Dict[str, DataLoader],
+    num_classes: int,
+    criterion,
+    optimizer,
+    scheduler=None,
+    num_epochs: int = 100,
+    device: Optional[torch.device] = None,
+    uncertainty: bool = False,
+) -> Tuple[torch.nn.Module, TrainingHistoryV1]:
+    config = TrainingConfigV1(num_epochs=num_epochs, num_classes=num_classes, uncertainty=uncertainty)
+    if device is None:
+        device = get_device()
+    model = model.to(device)
+
+    since = time.perf_counter()
+    best_model_wts = copy.deepcopy(model.state_dict())
+    best_acc = 0.0
+    best_epoch = -1
+    history: List[EpochMetricsV1] = []
+
+    for epoch in range(config.num_epochs):
+        print(f"Epoch {epoch + 1}/{config.num_epochs}")
+        print("-" * 10)
+
+        for phase in ("train", "val"):
+            if phase not in dataloaders:
+                continue
+            is_train = phase == "train"
+            model.train(mode=is_train)
+
+            running_loss = 0.0
+            running_corrects = 0.0
+            evidence_sum = 0.0
+            success_evidence_sum = 0.0
+            fail_evidence_sum = 0.0
+            uncertainty_sum = 0.0
+            match_sum = 0.0
+            sample_count = 0
+
+            for inputs, labels, *_ in dataloaders[phase]:
+                inputs = inputs.to(device)
+                labels = labels.to(device)
+                optimizer.zero_grad()
+
+                with torch.set_grad_enabled(is_train):
+                    outputs = model(inputs)
+                    _, preds = torch.max(outputs, 1)
+                    if config.uncertainty:
+                        targets = one_hot_embedding(labels, config.num_classes)
+                        loss = criterion(
+                            outputs,
+                            targets.float(),
+                            epoch,
+                            config.num_classes,
+                            10,
+                            device,
+                        )
+                        match = torch.eq(preds, labels).float().unsqueeze(1)
+                        evidence = relu_evidence(outputs)
+                        alpha = evidence + 1
+                        batch_uncertainty = (
+                            config.num_classes / torch.sum(alpha, dim=1, keepdim=True)
+                        )
+                        batch_total_evidence = torch.sum(evidence, dim=1, keepdim=True)
+
+                        evidence_sum += batch_total_evidence.sum().item()
+                        success_evidence_sum += (batch_total_evidence * match).sum().item()
+                        fail_evidence_sum += (
+                            batch_total_evidence * (1.0 - match)
+                        ).sum().item()
+                        uncertainty_sum += batch_uncertainty.sum().item()
+                        match_sum += match.sum().item()
+                    else:
+                        loss = criterion(outputs, labels)
+
+                    if is_train:
+                        loss.backward()
+                        optimizer.step()
+
+                running_loss += loss.item() * inputs.size(0)
+                running_corrects += torch.sum(preds == labels).item()
+                sample_count += inputs.size(0)
+
+            if scheduler is not None and is_train:
+                scheduler.step()
+
+            dataset_size = len(dataloaders[phase].dataset)
+            if dataset_size == 0:
+                continue
+            epoch_loss = running_loss / dataset_size
+            epoch_acc = running_corrects / dataset_size
+
+            if config.uncertainty and sample_count:
+                mean_evidence = evidence_sum / sample_count
+                successes = match_sum
+                failures = sample_count - successes
+                mean_evidence_success = success_evidence_sum / successes if successes else None
+                mean_evidence_fail = fail_evidence_sum / failures if failures else None
+                mean_uncertainty = uncertainty_sum / sample_count
+            else:
+                mean_evidence = None
+                mean_evidence_success = None
+                mean_evidence_fail = None
+                mean_uncertainty = None
+
+            history.append(
+                EpochMetricsV1(
+                    epoch=epoch,
+                    phase=phase,
+                    loss=epoch_loss,
+                    accuracy=epoch_acc,
+                    mean_evidence=mean_evidence,
+                    mean_evidence_success=mean_evidence_success,
+                    mean_evidence_fail=mean_evidence_fail,
+                    mean_uncertainty=mean_uncertainty,
+                )
+            )
+
+            print(f"{phase.capitalize()} loss: {epoch_loss:.4f} acc: {epoch_acc:.4f}")
+            if not is_train and epoch_acc > best_acc:
+                best_acc = epoch_acc
+                best_model_wts = copy.deepcopy(model.state_dict())
+                best_epoch = epoch
+
+        print()
+
+    duration = time.perf_counter() - since
+    print("Training complete in {:.0f}m {:.0f}s".format(duration // 60, duration % 60))
+    print(f"Best val Acc: {best_acc:.4f}")
+
+    model.load_state_dict(best_model_wts)
+    metrics = TrainingHistoryV1(
+        epochs=history,
+        best_epoch=best_epoch,
+        best_accuracy=best_acc,
+        duration_seconds=duration,
+    )
+    return model, metrics

--- a/README.md
+++ b/README.md
@@ -23,6 +23,42 @@
 ## Datasets
 * Any publicly available dataset that includes bearing or gear vibration signals can use this method.
 
+## Refactored CLI (v1)
+
+The repository now contains a standalone, script-style interface that does not rely on
+Python packages or `__init__.py` files. The new entry point is
+`Eviformer/cli_v1.py`, which can be executed directly:
+
+```
+python Eviformer/cli_v1.py train \
+  --data-root "D:/CWRU_Bearing_NumPy-main/Data" \
+  --model mcswint \
+  --epochs 100
+```
+
+Key features of the refactored pipeline include:
+
+* **Scan mode** for reproducing the verbose directory listing shown in the data
+  description:
+
+  ```
+  python Eviformer/cli_v1.py scan --data-root "D:/CWRU_Bearing_NumPy-main/Data"
+  ```
+
+* **Inspect mode** for printing dataset metadata without launching training:
+
+  ```
+  python Eviformer/cli_v1.py inspect --data-root "D:/CWRU_Bearing_NumPy-main/Data"
+  ```
+
+* **Train/Test modes** that share a simplified configuration surface while
+  maintaining the original evidential learning capabilities. Checkpoints are
+  stored at `./results/model_v1.pt` by default.
+
+All helper modules that support the CLI follow the `*_v1.py` naming convention
+for clarity (`data_pipeline_v1.py`, `model_factory_v1.py`, `training_loop_v1.py`,
+`evaluation_v1.py`, and `sequence_dataset_v1.py`).
+
 * ## Citation
 If our work is useful to you, please cite the following paper, it is the greatest encouragement to our open source work, thank you very much!
 ```


### PR DESCRIPTION
## Summary
- add a standalone v1 command line interface that orchestrates training, testing, inspection and data scanning without package-style imports
- introduce v1 data, dataset, model, training and evaluation helpers to simplify access to the CWRU `.npz` files and evidential learning utilities
- document the new workflow in the README with example commands targeting the provided Windows data directory

## Testing
- python -m compileall cli_v1.py data_pipeline_v1.py sequence_dataset_v1.py training_loop_v1.py evaluation_v1.py model_factory_v1.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d04a118c83328169ee85de8e37a4